### PR TITLE
map_pixels_to_ascii_chars width 

### DIFF
--- a/community-version.py
+++ b/community-version.py
@@ -66,7 +66,7 @@ def convert_image_to_ascii(image, reverse=False, new_width=None):
     image = scale_image(image, new_width)
     image = convert_to_grayscale(image)
 
-    pixels_to_chars = map_pixels_to_ascii_chars(image, reverse, new_width)
+    pixels_to_chars = map_pixels_to_ascii_chars(image, reverse)
     len_pixels_to_chars = len(pixels_to_chars)
 
     image_ascii = [pixels_to_chars[index: index + new_width] for index in

--- a/community-version.py
+++ b/community-version.py
@@ -44,11 +44,14 @@ def convert_to_grayscale(image):
     return image.convert('L')
 
 
-def map_pixels_to_ascii_chars(image, reverse, range_width=25):
+def map_pixels_to_ascii_chars(image, reverse):
     """Maps each pixel to an ascii char based on the range
     in which it lies.
-    0-255 is divided into 11 ranges of 25 pixels each.
+    0-255 is divided into ranges of pixels based on the number of
+    characters in ASCII_CHARS.
     """
+    # Calculates the ranges of pixels based on the number of characters in ASCII_CHARS
+    range_width = int(255 / (len(ASCII_CHARS) - 1))
 
     # We make a local copy on reverse so we don't modify the global array.
     ascii_chars = ASCII_CHARS if not reverse else ASCII_CHARS[::-1]


### PR DESCRIPTION
The width for map_pixels_to_ascii_chars is not related to image width, but rather is 255 divided by the length of the ascii char list, set to default of 25. Also, moved range_width from a parameter to a calculated value. This will also allow for adjusting the size of the ASCII_CHARS list. 