### PR TITLE
added saving ascii image to txt file

### DIFF
--- a/community-version.py
+++ b/community-version.py
@@ -31,6 +31,12 @@ def map_pixels_to_ascii_chars(image, range_width=25):
 
     return "".join(pixels_to_chars)
 
+def saving_image_to_txt(image_ascii, image_path):
+    with open(image_path, "w") as f:
+        f.write(image_ascii)
+        return
+    
+
 def convert_image_to_ascii(image, new_width=100):
     image = scale_image(image)
     image = convert_to_grayscale(image)
@@ -53,11 +59,18 @@ def handle_image_conversion(image_filepath):
         return
 
     image_ascii = convert_image_to_ascii(image)
-    print(image_ascii)
+    return image_ascii
 
 if __name__=='__main__':
     import sys
 
     image_file_path = sys.argv[1]
     print(image_file_path)
-    handle_image_conversion(image_file_path)
+    
+    if len(sys.argv) == 2:
+        _ = handle_image_conversion(image_file_path)
+    elif len(sys.argv) == 3:
+        txt_file_path = sys.argv[2]
+        ascii_image = handle_image_conversion(image_file_path)
+        saving_image_to_txt(ascii_image, txt_file_path)
+        


### PR DESCRIPTION
This pull request to `community-version.py` includes changes to enhance the functionality of image conversion to ASCII art. The most important changes include adding a new function to save the ASCII art to a text file and modifying the image conversion process to support this new functionality.

Enhancements to functionality:

* [`community-version.py`](diffhunk://#diff-7969bfd0923b02d1bc944bea7d3cf38e5464c24162f6a1b01f68ffcc3a56fbcdR34-R39): Added a new function `saving_image_to_txt` to save ASCII art to a text file.
* [`community-version.py`](diffhunk://#diff-7969bfd0923b02d1bc944bea7d3cf38e5464c24162f6a1b01f68ffcc3a56fbcdL56-R76): Modified `handle_image_conversion` to return the ASCII art string instead of printing it directly.
* [`community-version.py`](diffhunk://#diff-7969bfd0923b02d1bc944bea7d3cf38e5464c24162f6a1b01f68ffcc3a56fbcdL56-R76): Updated the main execution block to handle an optional second command-line argument for specifying the output text file path, and save the ASCII art to the file if provided.