### PR TITLE
Flip image feature 

### DIFF
--- a/community-version.py
+++ b/community-version.py
@@ -37,7 +37,13 @@ def apply_image_filters(image: Image.Image, brightness: float, contrast: float, 
         image = image.filter(ImageFilter.SHARPEN)
 
     return image
-
+# Function to flip image
+def flip_image(image: Image.Image, flip_horizontal: bool, flip_vertical: bool) -> Image.Image:
+    if flip_horizontal:
+        image = ImageOps.mirror(image)  # Flip horizontally
+    if flip_vertical:
+        image = ImageOps.flip(image)  # Flip vertically
+    return image
 
 # Function to dynamically adjust aspect ratio based on ASCII pattern
 def get_aspect_ratio(pattern: str) -> float:

--- a/community-version.py
+++ b/community-version.py
@@ -205,6 +205,9 @@ def main():
     parser.add_argument('--colorize', action='store_true', help='Enable colorized ASCII art')
     parser.add_argument('--theme', type=str, default='grayscale', choices=COLOR_THEMES.keys(),
                         help='Choose a color theme for colorized ASCII art')
+    parser.add_argument('--flip-horizontal', action='store_true', help='Flip the image horizontally')
+    parser.add_argument('--flip-vertical', action='store_true', help='Flip the image vertically')
+
 
     args = parser.parse_args()
 

--- a/community-version.py
+++ b/community-version.py
@@ -108,6 +108,10 @@ def run_streamlit_app():
     color_theme = st.sidebar.selectbox("Choose Color Theme", options=list(COLOR_THEMES.keys()))
     width = st.sidebar.slider("Set ASCII Art Width", 50, 150, 100)
 
+    # New Flip Image Feature
+    flip_horizontal = st.sidebar.checkbox("Flip Image Horizontally")
+    flip_vertical = st.sidebar.checkbox("Flip Image Vertically")
+
     # Image filters
     brightness = st.sidebar.slider("Brightness", 0.5, 2.0, 1.0)
     contrast = st.sidebar.slider("Contrast", 0.5, 2.0, 1.0)


### PR DESCRIPTION
This PR introduces a new feature that allows users to flip their images horizontally and/or vertically before generating ASCII art. The feature is available both in the Streamlit app (with new checkboxes in the sidebar) and in the CLI (with new --flip-horizontal and --flip-vertical flags).

### Changes:
1. Added flip_image function to apply horizontal and vertical flips.
2. Updated Streamlit sidebar to include flip options.
3. Added CLI arguments --flip-horizontal and --flip-vertical for flipping.