### PR TITLE
Improved color theme selection UI in Streamlit App

### DIFF
--- a/community-version.py
+++ b/community-version.py
@@ -102,7 +102,8 @@ def run_streamlit_app():
     st.sidebar.title("Settings")
     pattern_type = st.sidebar.selectbox("Choose ASCII Pattern", options=['basic', 'complex', 'emoji'])
     colorize = st.sidebar.checkbox("Enable Colorized ASCII Art")
-    color_theme = st.sidebar.selectbox("Choose Color Theme", options=list(COLOR_THEMES.keys()))
+    if colorize:
+        color_theme = st.sidebar.selectbox("Choose Color Theme", options=list(COLOR_THEMES.keys()))
     width = st.sidebar.slider("Set ASCII Art Width", 50, 150, 100)
 
     # New Flip Image Feature


### PR DESCRIPTION
The current implementation allows users to select a color theme even when the colorized ASCII Art is not enabled, which can be confusing for users.
![image](https://github.com/user-attachments/assets/4ad38226-fde1-4fde-9f69-2f85bdfcf41b)

![image](https://github.com/user-attachments/assets/a053ff5a-71be-4715-bacb-8df29cb16535)

This PR modifies the Streamlit app to only display and use the color theme selection when colorized ASCII Art is enabled. 