### PR TITLE
Fix missing import of 'os' for is_valid_image_path function

### DIFF
--- a/community-version.py
+++ b/community-version.py
@@ -4,6 +4,7 @@ import numpy as np
 import random
 import argparse
 import sys
+import os
 
 # ASCII patterns and color themes
 ASCII_PATTERNS = {


### PR DESCRIPTION
I was going through the community-version.py and noticed that that the os library was being used in the is_valid_image_path() function but hadn't been imported (line 169-172). I figured that this could lead to errors so I have adressed this in a new branch. I am new to open source contributions and I would love to contribute to projects so please let me know if you have any suggestions.